### PR TITLE
libfilezilla: fix license

### DIFF
--- a/pkgs/all-pkgs/l/libfilezilla/default.nix
+++ b/pkgs/all-pkgs/l/libfilezilla/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://lib.filezilla-project.org/index.php";
-    license = licenses.lpgl21;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [
       wkennington
     ];


### PR DESCRIPTION
lpgl21 is not only misspelled, but according to my check (https://svn.filezilla-project.org/filezilla/libfilezilla/trunk/README?revision=8693&view=markup and https://svn.filezilla-project.org/filezilla/libfilezilla/trunk/COPYING?revision=7050&view=markup) also incorrect.