### PR TITLE
yelp-xsl: remove GFDL reference

### DIFF
--- a/pkgs/all-pkgs/y/yelp-xsl/default.nix
+++ b/pkgs/all-pkgs/y/yelp-xsl/default.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation rec {
     description = "XSL stylesheets for yelp";
     homepage = https://git.gnome.org/browse/yelp-xsl;
     license = with licenses; [
-      fdl11
       gpl2Plus
       lgpl21Plus
       mit


### PR DESCRIPTION
fdl11 is not defined in lib/licenses.nix and I have found no indication that it applies in the repository