### PR TITLE
nvidia-cuda-toolkit: allow name to evaluate even on unsupported platforms

### DIFF
--- a/pkgs/all-pkgs/n/nvidia-cuda-toolkit/default.nix
+++ b/pkgs/all-pkgs/n/nvidia-cuda-toolkit/default.nix
@@ -33,7 +33,7 @@ let
 
   source = (import ./sources.nix { })."${channel}";
 
-  version = channel + "." + source."rev_${targetSystem}";
+  version = channel + "." + (source."rev_${targetSystem}" or "unsupported");
 in
 stdenv.mkDerivation rec {
   name = "nvidia-cuda-toolkit-${version}";


### PR DESCRIPTION
This breaks `nix-env -qa` since mkDerivation tries to format a nice error message about non-support of this platform, including the package name.